### PR TITLE
RUDI-2414 : Doc.rudi.bzh, la recherche ne fonctionne plus

### DIFF
--- a/search.json
+++ b/search.json
@@ -32,7 +32,8 @@ layout: null
   {%- endfor -%}
   {%- if counter > 0 -%},{% assign counter = 0 %}{%- endif -%}
 
-  {%- for collection in site.collections -%}
+  {% assign collections_not_empty = site.collections | where_exp: "item", "item.docs.size > 0" %}
+  {%- for collection in collections_not_empty -%}
     {%- if collection.docs.size > 0 -%}
       {%- for page in collection.docs -%}{% assign counter = counter | plus:1 %}
       {
@@ -46,5 +47,6 @@ layout: null
       }{% unless forloop.last %},{% endunless %}
       {%- endfor -%}
     {%- endif -%}
+    {% unless forloop.last %},{% endunless %}
   {%- endfor -%}
 ]


### PR DESCRIPTION
Correction du fichier "search.json" pour générer un fichier bien formatté + gérer les collections avec des pages vides à l'avenir